### PR TITLE
Fix failing tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/build/html/*
 .venv
 .env
 t.py
+.coverage.*

--- a/src/rush/stores/redis.py
+++ b/src/rush/stores/redis.py
@@ -49,6 +49,7 @@ class RedisStore(base.BaseStore):
     @client.default
     def _make_client(self):
         """Create the Redis client from the URL and config."""
+        attr.validate(self)  # Force validation of self.url
         self.client_config.setdefault("decode_responses", True)
         return redis.StrictRedis.from_url(
             url=self.url.unsplit(), **self.client_config

--- a/test/unit/helpers.py
+++ b/test/unit/helpers.py
@@ -11,7 +11,7 @@ class MockStore(stores.BaseStore):
     """Mock out the BaseStore to pass isinstance checks."""
 
     def __init__(self, recording_store=None):
-        """Set-up our mocked out store."""
+        """Set up our mocked out store."""
         self.recording_store = recording_store or mock.Mock(
             spec=["get", "get_with_time", "set", "set_with_time"]
         )

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ skip_install = true
 deps =
     -rlint-requirements.txt
 commands =
-    black -l 78 {env:BLACK_ARGS:} --py36 --safe src/rush test/
+    black -l 78 {env:BLACK_ARGS:} --target-version py36 --safe src/rush test/
     flake8 src/rush test
     pylint src/rush test
     mypy src/rush


### PR DESCRIPTION
There was a deprecation warning from `tox`, failing `pylint`, and a failing `RedisStore` test when I ran `tox` on the master branch. So I've sorted these three problems.